### PR TITLE
Fix output type of undef operation

### DIFF
--- a/include/JLM/JLMOps.td
+++ b/include/JLM/JLMOps.td
@@ -116,7 +116,7 @@ def JLM_Undef: JLM_Op<"undef"> {
     }];
 
     let results = (outs
-        AnyTypeOf<[RVSDG_Ctrl]>:$output
+        AnyType:$output
     );
 
     let assemblyFormat = "attr-dict `:` type($output)";


### PR DESCRIPTION
The output of an undef node should be AnyType to reflect the structure found in jlm 